### PR TITLE
Python3 compat

### DIFF
--- a/requests_aws_sign/requests_aws_sign.py
+++ b/requests_aws_sign/requests_aws_sign.py
@@ -1,6 +1,10 @@
+try:
+    from urllib.parse import urlparse
+except ImportError:
+    from urlparse import urlparse
+
 from botocore.auth import SigV4Auth
 from botocore.awsrequest import AWSRequest
-from urlparse import urlparse
 import requests
 
 class AWSV4Sign(requests.auth.AuthBase):

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup
 
 setup(
     name='requests_aws_sign',
-    version='0.1.2.dev0',
+    version='0.1.2',
     packages=[ 'requests_aws_sign' ],
     install_requires=[ 'requests>=2.0.0', 'boto3' ],
     provides=[ 'requests_aws_sign' ],
@@ -25,6 +25,7 @@ setup(
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
         'License :: OSI Approved :: ISC License (ISCL)',
     ],
 )

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup
 
 setup(
     name='requests_aws_sign',
-    version='0.1.1',
+    version='0.1.2.dev0',
     packages=[ 'requests_aws_sign' ],
     install_requires=[ 'requests>=2.0.0', 'boto3' ],
     provides=[ 'requests_aws_sign' ],


### PR DESCRIPTION
urlparse was removed in Python 3. It would be great if you could do a patch release for this.