### PR TITLE
Moves requirements from install_requires to requirements.txt, since

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
-.
+requests>=2.0.0
+boto3

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,6 @@ setup(
     name='requests_aws_sign',
     version='0.1.3',
     packages=[ 'requests_aws_sign' ],
-    install_requires=[ 'requests>=2.0.0', 'boto3' ],
     provides=[ 'requests_aws_sign' ],
     author='Justin Menga',
     author_email='justin.menga@gmail.com',


### PR DESCRIPTION
the package doesn't require them to run. This is particularly important
for AWS lambda deployments, where dependencies must be included in the
deployment package. In it's current form setup.py forces the inclusion
of boto3, which is unnecessary bloat for deployed lambdas.